### PR TITLE
Fix/contracts

### DIFF
--- a/contracts/abi/contracts/FlexiSwap.sol/FlexiSwap.json
+++ b/contracts/abi/contracts/FlexiSwap.sol/FlexiSwap.json
@@ -338,5 +338,82 @@
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_itemsId",
+        "type": "uint256"
+      }
+    ],
+    "name": "items",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "nftAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isEmptyToken",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct IFlexiSwap.Item[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tradeId",
+        "type": "uint256"
+      }
+    ],
+    "name": "trade",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "initiator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "givingsId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "receivingsIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "counterOfferItemsIds",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct IFlexiSwap.Trade",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/contracts/abi/contracts/FlexiSwap.sol/FlexiSwap.json
+++ b/contracts/abi/contracts/FlexiSwap.sol/FlexiSwap.json
@@ -211,52 +211,6 @@
         "internalType": "struct IFlexiSwap.Trade",
         "name": "trade",
         "type": "tuple"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[]",
-        "name": "givings",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[][]",
-        "name": "receivings",
-        "type": "tuple[][]"
       }
     ],
     "name": "TradeCreated",

--- a/contracts/abi/contracts/FlexiSwap.sol/FlexiSwap.json
+++ b/contracts/abi/contracts/FlexiSwap.sol/FlexiSwap.json
@@ -122,29 +122,6 @@
         "internalType": "uint256",
         "name": "itemsId",
         "type": "uint256"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[]",
-        "name": "offerItems",
-        "type": "tuple[]"
       }
     ],
     "name": "CounterOfferCreated",

--- a/contracts/abi/contracts/FlexiSwapCore.sol/FlexiSwapCore.json
+++ b/contracts/abi/contracts/FlexiSwapCore.sol/FlexiSwapCore.json
@@ -338,5 +338,82 @@
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_itemsId",
+        "type": "uint256"
+      }
+    ],
+    "name": "items",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "nftAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isEmptyToken",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct IFlexiSwap.Item[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tradeId",
+        "type": "uint256"
+      }
+    ],
+    "name": "trade",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "initiator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "givingsId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "receivingsIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "counterOfferItemsIds",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct IFlexiSwap.Trade",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/contracts/abi/contracts/FlexiSwapCore.sol/FlexiSwapCore.json
+++ b/contracts/abi/contracts/FlexiSwapCore.sol/FlexiSwapCore.json
@@ -211,52 +211,6 @@
         "internalType": "struct IFlexiSwap.Trade",
         "name": "trade",
         "type": "tuple"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[]",
-        "name": "givings",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[][]",
-        "name": "receivings",
-        "type": "tuple[][]"
       }
     ],
     "name": "TradeCreated",

--- a/contracts/abi/contracts/FlexiSwapCore.sol/FlexiSwapCore.json
+++ b/contracts/abi/contracts/FlexiSwapCore.sol/FlexiSwapCore.json
@@ -122,29 +122,6 @@
         "internalType": "uint256",
         "name": "itemsId",
         "type": "uint256"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[]",
-        "name": "offerItems",
-        "type": "tuple[]"
       }
     ],
     "name": "CounterOfferCreated",

--- a/contracts/abi/contracts/FlexiSwapValidator.sol/FlexiSwapValidator.json
+++ b/contracts/abi/contracts/FlexiSwapValidator.sol/FlexiSwapValidator.json
@@ -338,5 +338,82 @@
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_itemsId",
+        "type": "uint256"
+      }
+    ],
+    "name": "items",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "nftAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isEmptyToken",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct IFlexiSwap.Item[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tradeId",
+        "type": "uint256"
+      }
+    ],
+    "name": "trade",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "initiator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "givingsId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "receivingsIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "counterOfferItemsIds",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct IFlexiSwap.Trade",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/contracts/abi/contracts/FlexiSwapValidator.sol/FlexiSwapValidator.json
+++ b/contracts/abi/contracts/FlexiSwapValidator.sol/FlexiSwapValidator.json
@@ -211,52 +211,6 @@
         "internalType": "struct IFlexiSwap.Trade",
         "name": "trade",
         "type": "tuple"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[]",
-        "name": "givings",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[][]",
-        "name": "receivings",
-        "type": "tuple[][]"
       }
     ],
     "name": "TradeCreated",

--- a/contracts/abi/contracts/FlexiSwapValidator.sol/FlexiSwapValidator.json
+++ b/contracts/abi/contracts/FlexiSwapValidator.sol/FlexiSwapValidator.json
@@ -122,29 +122,6 @@
         "internalType": "uint256",
         "name": "itemsId",
         "type": "uint256"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[]",
-        "name": "offerItems",
-        "type": "tuple[]"
       }
     ],
     "name": "CounterOfferCreated",

--- a/contracts/abi/contracts/IFlexiSwap.sol/IFlexiSwap.json
+++ b/contracts/abi/contracts/IFlexiSwap.sol/IFlexiSwap.json
@@ -333,5 +333,82 @@
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_itemsId",
+        "type": "uint256"
+      }
+    ],
+    "name": "items",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "nftAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isEmptyToken",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct IFlexiSwap.Item[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tradeId",
+        "type": "uint256"
+      }
+    ],
+    "name": "trade",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "initiator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "givingsId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "receivingsIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "counterOfferItemsIds",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct IFlexiSwap.Trade",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/contracts/abi/contracts/IFlexiSwap.sol/IFlexiSwap.json
+++ b/contracts/abi/contracts/IFlexiSwap.sol/IFlexiSwap.json
@@ -117,29 +117,6 @@
         "internalType": "uint256",
         "name": "itemsId",
         "type": "uint256"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[]",
-        "name": "offerItems",
-        "type": "tuple[]"
       }
     ],
     "name": "CounterOfferCreated",

--- a/contracts/abi/contracts/IFlexiSwap.sol/IFlexiSwap.json
+++ b/contracts/abi/contracts/IFlexiSwap.sol/IFlexiSwap.json
@@ -206,52 +206,6 @@
         "internalType": "struct IFlexiSwap.Trade",
         "name": "trade",
         "type": "tuple"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[]",
-        "name": "givings",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "nftAddress",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "tokenId",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "isEmptyToken",
-            "type": "bool"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct IFlexiSwap.Item[][]",
-        "name": "receivings",
-        "type": "tuple[][]"
       }
     ],
     "name": "TradeCreated",

--- a/contracts/contracts/FlexiSwapCore.sol
+++ b/contracts/contracts/FlexiSwapCore.sol
@@ -11,13 +11,13 @@ contract FlexiSwapCore is IFlexiSwap {
     Counters.Counter internal _itemsIds;
 
     // tradeId => trade
-    mapping(uint256 => Trade) internal trades;
+    mapping(uint256 => Trade) internal _trades;
 
     // itemsId => items[]
-    mapping(uint256 => Item[]) internal items;
+    mapping(uint256 => Item[]) internal _items;
 
     // itemsId => initiatorAddress
-    mapping(uint256 => address) internal counterOfferInitiators;
+    mapping(uint256 => address) internal _counterOfferInitiators;
 
     constructor() {
         // constructor
@@ -30,7 +30,7 @@ contract FlexiSwapCore is IFlexiSwap {
         uint256 itemsId = _itemsIds.current();
         _itemsIds.increment();
         for (uint256 i = 0; i < _itemsToRegister.length; i++) {
-            items[itemsId].push(_itemsToRegister[i]);
+            _items[itemsId].push(_itemsToRegister[i]);
         }
         return itemsId;
     }
@@ -61,7 +61,7 @@ contract FlexiSwapCore is IFlexiSwap {
             counterOfferItemsIds: new uint256[](0)
         });
 
-        trades[tradeId] = trade;
+        _trades[tradeId] = trade;
 
         emit TradeCreated(tradeId, trade, _givings, _receivings);
     }
@@ -81,9 +81,9 @@ contract FlexiSwapCore is IFlexiSwap {
     {
         uint256 counterOfferItemsId = registerItemsToStorage(_offerItems);
 
-        trades[_tradeId].counterOfferItemsIds.push(counterOfferItemsId);
-        
-        counterOfferInitiators[counterOfferItemsId] = msg.sender;
+        _trades[_tradeId].counterOfferItemsIds.push(counterOfferItemsId);
+
+        _counterOfferInitiators[counterOfferItemsId] = msg.sender;
 
         emit CounterOfferCreated(
             msg.sender,

--- a/contracts/contracts/FlexiSwapCore.sol
+++ b/contracts/contracts/FlexiSwapCore.sol
@@ -35,6 +35,14 @@ contract FlexiSwapCore is IFlexiSwap {
         return itemsId;
     }
 
+    function trade(uint256 _tradeId) external view returns (Trade memory) {
+        return _trades[_tradeId];
+    }
+
+    function items(uint256 _itemsId) external view returns (Item[] memory) {
+        return _items[_itemsId];
+    }
+
     function createTrade(Item[] memory _givings, Item[][] memory _receivings)
         public
         virtual

--- a/contracts/contracts/FlexiSwapCore.sol
+++ b/contracts/contracts/FlexiSwapCore.sol
@@ -63,7 +63,7 @@ contract FlexiSwapCore is IFlexiSwap {
 
         _trades[tradeId] = trade;
 
-        emit TradeCreated(tradeId, trade, _givings, _receivings);
+        emit TradeCreated(tradeId, trade);
     }
 
     function acceptOffer(uint256 _tradeId, uint256 _itemsId)

--- a/contracts/contracts/FlexiSwapCore.sol
+++ b/contracts/contracts/FlexiSwapCore.sol
@@ -96,8 +96,7 @@ contract FlexiSwapCore is IFlexiSwap {
         emit CounterOfferCreated(
             msg.sender,
             _tradeId,
-            counterOfferItemsId,
-            _offerItems
+            counterOfferItemsId
         );
     }
 

--- a/contracts/contracts/FlexiSwapValidator.sol
+++ b/contracts/contracts/FlexiSwapValidator.sol
@@ -11,14 +11,14 @@ contract FlexiSwapValidator is FlexiSwapCore {
     }
 
     modifier tradeExists(uint256 tradeId) {
-        if (trades[tradeId].initiator == address(0)) {
+        if (_trades[tradeId].initiator == address(0)) {
             revert TradeDoesNotExist(tradeId);
         }
         _;
     }
 
     modifier offerExists(uint256 tradeId, uint256 itemsId) {
-        Trade memory trade = trades[tradeId];
+        Trade memory trade = _trades[tradeId];
         for (uint256 i = 0; i < trade.receivingsIds.length; i++) {
             if (trade.receivingsIds[i] == itemsId) {
                 _;
@@ -30,7 +30,7 @@ contract FlexiSwapValidator is FlexiSwapCore {
     }
 
     modifier counterOfferExists(uint256 tradeId, uint256 itemsId) {
-        Trade memory trade = trades[tradeId];
+        Trade memory trade = _trades[tradeId];
         for (uint256 i = 0; i < trade.counterOfferItemsIds.length; i++) {
             if (trade.counterOfferItemsIds[i] == itemsId) {
                 _;
@@ -73,24 +73,24 @@ contract FlexiSwapValidator is FlexiSwapCore {
     }
 
     modifier notTradeOwner(uint256 tradeId) {
-        if (trades[tradeId].initiator == msg.sender) {
+        if (_trades[tradeId].initiator == msg.sender) {
             revert InvalidForTradeOwner();
         }
         _;
     }
 
     modifier isTradeOwner(uint256 tradeId) {
-        if (trades[tradeId].initiator != msg.sender) {
+        if (_trades[tradeId].initiator != msg.sender) {
             revert TradeOwnerOnly();
         }
         _;
     }
 
     modifier notExistingCounterOffer(uint256 tradeId, address counterOfferer) {
-        Trade memory trade = trades[tradeId];
+        Trade memory trade = _trades[tradeId];
         for (uint256 i = 0; i < trade.counterOfferItemsIds.length; i++) {
             uint counterOfferItemsId = trade.counterOfferItemsIds[i];
-            if (counterOfferer == counterOfferInitiators[counterOfferItemsId]) {
+            if (counterOfferer == _counterOfferInitiators[counterOfferItemsId]) {
                 revert CounterOfferAlreadyExists(tradeId, counterOfferItemsId);
             }
         }

--- a/contracts/contracts/IFlexiSwap.sol
+++ b/contracts/contracts/IFlexiSwap.sol
@@ -27,12 +27,7 @@ interface IFlexiSwap {
     error TradeOwnerOnly();
     error InvalidForTradeOwner();
 
-    event TradeCreated(
-        uint256 tradeId,
-        Trade trade,
-        Item[] givings,
-        Item[][] receivings
-    );
+    event TradeCreated(uint256 tradeId, Trade trade);
     event TradeAccepted(address accepter, uint256 tradeId, uint256 itemsId);
     event CounterOfferCreated(
         address counterOfferer,

--- a/contracts/contracts/IFlexiSwap.sol
+++ b/contracts/contracts/IFlexiSwap.sol
@@ -32,8 +32,7 @@ interface IFlexiSwap {
     event CounterOfferCreated(
         address counterOfferer,
         uint256 tradeId,
-        uint256 itemsId,
-        Item[] offerItems
+        uint256 itemsId
     );
     event CounterOfferAccepted(uint256 tradeId, uint256 itemsId);
 

--- a/contracts/contracts/IFlexiSwap.sol
+++ b/contracts/contracts/IFlexiSwap.sol
@@ -37,6 +37,10 @@ interface IFlexiSwap {
     );
     event CounterOfferAccepted(uint256 tradeId, uint256 itemsId);
 
+    function trade(uint256 _tradeId) external view returns (Trade memory);
+
+    function items(uint256 _itemsId) external view returns (Item[] memory);
+
     function createTrade(Item[] memory _givings, Item[][] memory _receivings)
         external;
 


### PR DESCRIPTION
This PR introduces 2 new external getters for `trade` & `items`. `items` getter is required for The Graph mappings as Solidity type `tuple[][]` which was used in `TradeCreated` event for `receivings` **CAN NOT** be converted to AssemblyScript