### PR TITLE
fix: Metamask auth

### DIFF
--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
-import { useMoralis } from "react-moralis";
+import { useMoralis } from 'react-moralis';
 
 export const useAuth = () => {
-  const { user, isAuthenticated, authenticate, logout, account } = useMoralis();
-  return { user, isAuthenticated, login: authenticate, logout, account };
+  const { user, authenticate, logout, account, web3 } = useMoralis();
+  const signer = account && web3 ? web3.getSigner(account) : null;
+  return { user, login: authenticate, logout, account, signer };
 };

--- a/web/src/pages/Trades/components/TradesLayout/TradesLayout.tsx
+++ b/web/src/pages/Trades/components/TradesLayout/TradesLayout.tsx
@@ -22,7 +22,7 @@ interface TradesLayoutProps {
 
 export const TradesLayout: React.FC<TradesLayoutProps> = ({ onSearchChange, children }) => {
   const classes = useTradesSidebarStyles()
-  const { isAuthenticated } = useAuth()
+  const { account } = useAuth()
   const navigate = useNavigate()
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,7 +44,7 @@ export const TradesLayout: React.FC<TradesLayoutProps> = ({ onSearchChange, chil
         <FlexiButton onClick={handleCreateTrade}>Create trade</FlexiButton>
         <FlexiSubtitle className={classes.subtitle}>Marketplace</FlexiSubtitle>
         <SidebarList />
-        {!isAuthenticated && <ConnectWallet />}
+        {!account && <ConnectWallet />}
       </Sidebar>
       {children}
     </main>


### PR DESCRIPTION
I don't now why, but after I reload the page
```ts
const { isAuthenticated, account } = useMoralis();
```
`isAuthenticated === true` but `account === null`, thus account is a better option to determine if the user is authenticated