### PR TITLE
Add docs for IFlexiSwap.sol

### DIFF
--- a/contracts/abi/contracts/FlexiSwap.sol/FlexiSwap.json
+++ b/contracts/abi/contracts/FlexiSwap.sol/FlexiSwap.json
@@ -8,7 +8,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "counterOfferItemsId",
+        "name": "itemsId",
         "type": "uint256"
       }
     ],

--- a/contracts/abi/contracts/FlexiSwapCore.sol/FlexiSwapCore.json
+++ b/contracts/abi/contracts/FlexiSwapCore.sol/FlexiSwapCore.json
@@ -13,7 +13,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "counterOfferItemsId",
+        "name": "itemsId",
         "type": "uint256"
       }
     ],

--- a/contracts/abi/contracts/IFlexiSwap.sol/IFlexiSwap.json
+++ b/contracts/abi/contracts/IFlexiSwap.sol/IFlexiSwap.json
@@ -8,7 +8,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "counterOfferItemsId",
+        "name": "itemsId",
         "type": "uint256"
       }
     ],

--- a/contracts/contracts/IFlexiSwap.sol
+++ b/contracts/contracts/IFlexiSwap.sol
@@ -1,6 +1,16 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
+/**
+ * @title Interface of the FlexiSwap contract.
+ * @notice FlexiSwap is a swap tool with unique features for swapping NFTs and NFT collections.
+ *
+ * Key features:
+ * 1. **Batch swaps:** allows users to swap multiple NFTs for multiple other NFTs within a single transaction.
+ * 2. **Wish lists:** allows users to create a customized list of up to 10 options per their swap offer to curate a collection of one or several NFTs that they are interested in exchanging.
+ * 3. **Collection wish list:** allows users to create a list of desired NFTs from a specific collection for their swap offers.
+ * 4. **Counter offers:** allows users to engage in dynamic negotiations and respond to swap offers with alternative proposals.
+ */
 interface IFlexiSwap {
     struct Trade {
         address initiator;
@@ -15,43 +25,168 @@ interface IFlexiSwap {
         bool isEmptyToken;
     }
 
+    /**
+     * @notice Emitted when trade with `tradeId` does not exist.
+     * @param tradeId The id of the trade.
+     */
     error TradeDoesNotExist(uint256 tradeId);
+
+    /**
+     * @notice Emitted when offer with `itemsId` does not exist in trade with `tradeId`.
+     * @param tradeId The id of the trade.
+     * @param itemsId The id of the offer items.
+     */
     error OfferDoesNotExist(uint256 tradeId, uint256 itemsId);
+
+    /**
+     * @notice Emitted when counter offer with `itemsId` does not exist in trade with `tradeId`.
+     * @param tradeId The id of the trade.
+     * @param itemsId The id of the counter offer items.
+     */
     error CounterOfferDoesNotExist(uint256 tradeId, uint256 itemsId);
-    error CounterOfferAlreadyExists(
-        uint256 tradeId,
-        uint256 counterOfferItemsId
-    );
+
+    /**
+     * @notice Emitted when counter offer with `counterOfferItemsId` already exists in trade with `tradeId`.
+     * @param tradeId The id of the trade.
+     * @param itemsId The id of the counter offer items.
+     */
+    error CounterOfferAlreadyExists(uint256 tradeId, uint256 itemsId);
+
+    /**
+     * @notice Emitted when trade has invalid number of offers.
+     */
     error InvalidTradeOffersNumber();
+
+    /**
+     * @notice Emitted when trade offer has invalid number of items.
+     */
     error InvalidTradeOffersItemNumber();
+
+    /**
+     * @notice Emitted when caller is not the trade owner.
+     */
     error TradeOwnerOnly();
+
+    /**
+     * @notice Emitted when caller is the trade owner.
+     */
     error InvalidForTradeOwner();
+
+    /**
+     * @notice Emitted when token with `nftAddress` and `tokenId` is not approved to use.
+     * @param nftAddress The address of the NFT contract.
+     * @param tokenId The id of the NFT token.
+     */
     error TokenNotApproved(address nftAddress, uint256 tokenId);
+
+    /**
+     * @notice Emitted when caller provide invalid additional assets.
+     */
     error InvalidAdditionalAssets();
 
+    /**
+     * @notice Emitted when trade is created with `tradeId` and `trade` data.
+     * @param tradeId The id of the trade.
+     * @param trade The trade data.
+     */
     event TradeCreated(uint256 tradeId, Trade trade);
+
+    /**
+     * @notice Emitted when trade with `tradeId` and `itemsId` is accepted by `accepter`.
+     * @param accepter The address of the trade accepter.
+     * @param tradeId The id of the trade.
+     * @param itemsId The id of the offer items.
+     */
     event TradeAccepted(address accepter, uint256 tradeId, uint256 itemsId);
-    event CounterOfferCreated(
-        address counterOfferer,
-        uint256 tradeId,
-        uint256 itemsId
-    );
+
+    /**
+     * @notice Emitted when counter offer with `itemsId` is offered by `counterOfferer` to trade with `tradeId`.
+     * @param counterOfferer The address of the trade counter offerer.
+     * @param tradeId The id of the trade.
+     * @param itemsId The id of the counter offer items.
+     */
+    event CounterOfferCreated(address counterOfferer, uint256 tradeId, uint256 itemsId);
+
+    /**
+     * @notice Emitted when counter offer with `itemsId` is accepted for trade with `tradeId`.
+     * @param tradeId The id of the trade.
+     * @param itemsId The id of the counter offer items.
+     */
     event CounterOfferAccepted(uint256 tradeId, uint256 itemsId);
 
+    /**
+     * @notice Returns the trade data by `_tradeId`.
+     * @param _tradeId The id of the trade.
+     * @return The trade data.
+     */
     function trade(uint256 _tradeId) external view returns (Trade memory);
 
+    /**
+     * @notice Returns the array offer of items data by `_itemsId`.
+     * @param _itemsId The id of the offer items.
+     * @return The array of items data.
+     */
     function items(uint256 _itemsId) external view returns (Item[] memory);
 
-    function createTrade(Item[] memory _givings, Item[][] memory _receivings)
-        external;
+    /**
+     * @notice Creates a new trade with items `_givings` to exchange for one of items `_receivings`.
+     *
+     * Requirements:
+     *
+     * - `_receivings` must have a valid number of offers.
+     * - `_receivings` must have a valid number of items per offer.
+     * - `_givings` must have a valid number of items.
+     *
+     * @param _givings The array of items to give.
+     * @param _receivings The array of wishlists of items to receive.
+     */
+    function createTrade(Item[] memory _givings, Item[][] memory _receivings) external;
 
-    // additionalAssets is a list of additional assets that the initiator wants to receive in addition to the items in the trade
-    // for exmple, if trade initiator stated that he wants 2 nfts from collection A in addition, then additionalAssets
-    // should contain strictly 2 nfts from collection A
+    /**
+     * @notice Accepts the trade with `_tradeId` and `_itemsId` and sends `_additionalAssets` to the trade initiator.
+     * @dev The `_additionalAssets` is a list of additional tokens that the initiator wants to receive in addition to the items in the trade,
+     * for example, if trade initiator stated that he wants 2 tokens from collection A in addition, then `_additionalAssets`
+     * should contain strictly 2 tokens from collection A.
+     *
+     * Requirements:
+     *
+     * - trade with `_tradeId` must exist.
+     * - caller cannot be the trade owner.
+     * - offer with `_itemsId` must exist in trade with `_tradeId`.
+     *
+     * @param _tradeId The id of the trade.
+     * @param _itemsId The id of the offer items.
+     * @param _additionalAssets The array of additional tokens to send.
+     */
     function acceptOffer(uint256 _tradeId, uint256 _itemsId, Item[] memory _additionalAssets) external;
 
-    function createCounterOffer(uint256 _tradeId, Item[] memory _offerItems)
-        external;
+    /**
+     * @notice Creates a counter offer with items `_offerItems` for trade with `_tradeId`.
+     *
+     * Requirements:
+     *
+     * - trade with `_tradeId` must exist.
+     * - caller cannot be the trade owner.
+     * - counter offer with `_offerItems` must not exist in trade with `_tradeId`.
+     * - `_offerItems` must have a valid length.
+     *
+     * @param _tradeId The id of the trade.
+     * @param _offerItems The array of items to offer.
+     */
+    function createCounterOffer(uint256 _tradeId, Item[] memory _offerItems) external;
 
+    /**
+     * @notice Accepts the counter offer for `_tradeId` and items with `_itemsId`.
+     * @dev All tokens which are included in the trade must be approved to use by contract.
+     *
+     * Requirements:
+     *
+     * - trade with `_tradeId` must exist.
+     * - caller must be the trade owner.
+     * - counter offer with `_itemsId` must exist in trade with `_tradeId`.
+     *
+     * @param _tradeId The id of the trade.
+     * @param _itemsId The id of the counter offer items.
+     */
     function acceptCounterOffer(uint256 _tradeId, uint256 _itemsId) external;
 }

--- a/contracts/docs/generated/IFlexiSwap.md
+++ b/contracts/docs/generated/IFlexiSwap.md
@@ -1,0 +1,322 @@
+# IFlexiSwap
+
+Interface of the FlexiSwap contract.
+FlexiSwap is a swap tool with unique features for swapping NFTs and NFT collections.
+
+Key features:
+1. **Batch swaps:** allows users to swap multiple NFTs for multiple other NFTs within a single transaction.
+2. **Wish lists:** allows users to create a customized list of up to 10 options per their swap offer to curate a collection of one or several NFTs that they are interested in exchanging.
+3. **Collection wish list:** allows users to create a list of desired NFTs from a specific collection for their swap offers.
+4. **Counter offers:** allows users to engage in dynamic negotiations and respond to swap offers with alternative proposals.
+
+## Errors
+### TradeDoesNotExist
+
+```solidity
+error TradeDoesNotExist(uint256 tradeId)
+```
+
+Emitted when trade with `tradeId` does not exist.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tradeId | uint256 | The id of the trade. |
+
+### OfferDoesNotExist
+
+```solidity
+error OfferDoesNotExist(uint256 tradeId, uint256 itemsId)
+```
+
+Emitted when offer with `itemsId` does not exist in trade with `tradeId`.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tradeId | uint256 | The id of the trade. |
+| itemsId | uint256 | The id of the offer items. |
+
+### CounterOfferDoesNotExist
+
+```solidity
+error CounterOfferDoesNotExist(uint256 tradeId, uint256 itemsId)
+```
+
+Emitted when counter offer with `itemsId` does not exist in trade with `tradeId`.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tradeId | uint256 | The id of the trade. |
+| itemsId | uint256 | The id of the counter offer items. |
+
+### CounterOfferAlreadyExists
+
+```solidity
+error CounterOfferAlreadyExists(uint256 tradeId, uint256 itemsId)
+```
+
+Emitted when counter offer with `counterOfferItemsId` already exists in trade with `tradeId`.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tradeId | uint256 | The id of the trade. |
+| itemsId | uint256 | The id of the counter offer items. |
+
+### InvalidTradeOffersNumber
+
+```solidity
+error InvalidTradeOffersNumber()
+```
+
+Emitted when trade has invalid number of offers.
+
+### InvalidTradeOffersItemNumber
+
+```solidity
+error InvalidTradeOffersItemNumber()
+```
+
+Emitted when trade offer has invalid number of items.
+
+### TradeOwnerOnly
+
+```solidity
+error TradeOwnerOnly()
+```
+
+Emitted when caller is not the trade owner.
+
+### InvalidForTradeOwner
+
+```solidity
+error InvalidForTradeOwner()
+```
+
+Emitted when caller is the trade owner.
+
+### TokenNotApproved
+
+```solidity
+error TokenNotApproved(address nftAddress, uint256 tokenId)
+```
+
+Emitted when token with `nftAddress` and `tokenId` is not approved to use.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| nftAddress | address | The address of the NFT contract. |
+| tokenId | uint256 | The id of the NFT token. |
+
+### InvalidAdditionalAssets
+
+```solidity
+error InvalidAdditionalAssets()
+```
+
+Emitted when caller provide invalid additional assets.
+
+## Events
+### TradeCreated
+
+```solidity
+event TradeCreated(uint256 tradeId, struct IFlexiSwap.Trade trade)
+```
+
+Emitted when trade is created with `tradeId` and `trade` data.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tradeId | uint256 | The id of the trade. |
+| trade | struct IFlexiSwap.Trade | The trade data. |
+
+### TradeAccepted
+
+```solidity
+event TradeAccepted(address accepter, uint256 tradeId, uint256 itemsId)
+```
+
+Emitted when trade with `tradeId` and `itemsId` is accepted by `accepter`.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| accepter | address | The address of the trade accepter. |
+| tradeId | uint256 | The id of the trade. |
+| itemsId | uint256 | The id of the offer items. |
+
+### CounterOfferCreated
+
+```solidity
+event CounterOfferCreated(address counterOfferer, uint256 tradeId, uint256 itemsId)
+```
+
+Emitted when counter offer with `itemsId` is offered by `counterOfferer` to trade with `tradeId`.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| counterOfferer | address | The address of the trade counter offerer. |
+| tradeId | uint256 | The id of the trade. |
+| itemsId | uint256 | The id of the counter offer items. |
+
+### CounterOfferAccepted
+
+```solidity
+event CounterOfferAccepted(uint256 tradeId, uint256 itemsId)
+```
+
+Emitted when counter offer with `itemsId` is accepted for trade with `tradeId`.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| tradeId | uint256 | The id of the trade. |
+| itemsId | uint256 | The id of the counter offer items. |
+
+## Events
+### trade
+
+```solidity
+function trade(uint256 _tradeId) external view returns (struct IFlexiSwap.Trade)
+```
+
+Returns the trade data by `_tradeId`.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _tradeId | uint256 | The id of the trade. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | struct IFlexiSwap.Trade | The trade data. |
+
+### items
+
+```solidity
+function items(uint256 _itemsId) external view returns (struct IFlexiSwap.Item[])
+```
+
+Returns the array offer of items data by `_itemsId`.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _itemsId | uint256 | The id of the offer items. |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | struct IFlexiSwap.Item[] | The array of items data. |
+
+### createTrade
+
+```solidity
+function createTrade(struct IFlexiSwap.Item[] _givings, struct IFlexiSwap.Item[][] _receivings) external
+```
+
+Creates a new trade with items `_givings` to exchange for one of items `_receivings`.
+
+Requirements:
+
+- `_receivings` must have a valid number of offers.
+- `_receivings` must have a valid number of items per offer.
+- `_givings` must have a valid number of items.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _givings | struct IFlexiSwap.Item[] | The array of items to give. |
+| _receivings | struct IFlexiSwap.Item[][] | The array of wishlists of items to receive. |
+
+### acceptOffer
+
+```solidity
+function acceptOffer(uint256 _tradeId, uint256 _itemsId, struct IFlexiSwap.Item[] _additionalAssets) external
+```
+
+Accepts the trade with `_tradeId` and `_itemsId` and sends `_additionalAssets` to the trade initiator.
+
+_The `_additionalAssets` is a list of additional tokens that the initiator wants to receive in addition to the items in the trade,
+for example, if trade initiator stated that he wants 2 tokens from collection A in addition, then `_additionalAssets`
+should contain strictly 2 tokens from collection A.
+
+Requirements:
+
+- trade with `_tradeId` must exist.
+- caller cannot be the trade owner.
+- offer with `_itemsId` must exist in trade with `_tradeId`._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _tradeId | uint256 | The id of the trade. |
+| _itemsId | uint256 | The id of the offer items. |
+| _additionalAssets | struct IFlexiSwap.Item[] | The array of additional tokens to send. |
+
+### createCounterOffer
+
+```solidity
+function createCounterOffer(uint256 _tradeId, struct IFlexiSwap.Item[] _offerItems) external
+```
+
+Creates a counter offer with items `_offerItems` for trade with `_tradeId`.
+
+Requirements:
+
+- trade with `_tradeId` must exist.
+- caller cannot be the trade owner.
+- counter offer with `_offerItems` must not exist in trade with `_tradeId`.
+- `_offerItems` must have a valid length.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _tradeId | uint256 | The id of the trade. |
+| _offerItems | struct IFlexiSwap.Item[] | The array of items to offer. |
+
+### acceptCounterOffer
+
+```solidity
+function acceptCounterOffer(uint256 _tradeId, uint256 _itemsId) external
+```
+
+Accepts the counter offer for `_tradeId` and items with `_itemsId`.
+
+_All tokens which are included in the trade must be approved to use by contract.
+
+Requirements:
+
+- trade with `_tradeId` must exist.
+- caller must be the trade owner.
+- counter offer with `_itemsId` must exist in trade with `_tradeId`._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _tradeId | uint256 | The id of the trade. |
+| _itemsId | uint256 | The id of the counter offer items. |
+

--- a/contracts/docs/templates/contract.hbs
+++ b/contracts/docs/templates/contract.hbs
@@ -1,0 +1,43 @@
+{{#if isInterface}}
+{{h 1}} {{name}}
+
+{{natspec.title}}
+{{natspec.notice}}
+{{#if natspec.dev}}
+_Developer note: {{natspec.dev}}_
+{{/if}}
+
+{{#if errors}}
+{{#hsection}}
+{{h}} Errors
+{{#hsection}}
+{{#each errors}}
+{{>item}}
+{{/each}}
+{{/hsection}}
+{{/hsection}}
+{{/if}}
+
+{{#if events}}
+{{#hsection}}
+{{h}} Events
+{{#hsection}}
+{{#each events}}
+{{>item}}
+{{/each}}
+{{/hsection}}
+{{/hsection}}
+{{/if}}
+
+{{#if functions}}
+{{#hsection}}
+{{h}} Events
+{{#hsection}}
+{{#each functions}}
+{{>item}}
+{{/each}}
+{{/hsection}}
+{{/hsection}}
+{{/if}}
+
+{{/if}}

--- a/contracts/docs/templates/page.hbs
+++ b/contracts/docs/templates/page.hbs
@@ -1,0 +1,3 @@
+{{#each items}}
+{{>item}}
+{{/each}}

--- a/contracts/docs/templates/properties.ts
+++ b/contracts/docs/templates/properties.ts
@@ -1,0 +1,6 @@
+import { DocItemContext } from 'solidity-docgen/dist/site';
+
+export function isInterface({ item }: DocItemContext): boolean {
+  if (item.nodeType !== 'ContractDefinition') return false;
+  return /^I[A-Z].*/.test(item.name);
+}

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -36,7 +36,7 @@ const config: HardhatUserConfig = {
     outputDir: './docs/generated',
     templates: './docs/templates',
     pages: 'files',
-    exclude: [],
+    exclude: ['TestToken.sol', 'FlexiSwap.sol', 'FlexiSwapCore.sol'],
   },
 };
 

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,9 +1,10 @@
 import * as dotenv from 'dotenv';
 
-import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-toolbox';
 import '@nomiclabs/hardhat-ganache';
 import 'hardhat-abi-exporter';
+import { HardhatUserConfig } from 'hardhat/config';
+import 'solidity-docgen';
 
 dotenv.config();
 
@@ -30,6 +31,12 @@ const config: HardhatUserConfig = {
   abiExporter: {
     runOnCompile: true,
     clear: true,
+  },
+  docgen: {
+    outputDir: './docs/generated',
+    templates: './docs/templates',
+    pages: 'files',
+    exclude: [],
   },
 };
 

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -19,6 +19,8 @@
         "dotenv": "^16.0.2",
         "hardhat": "^2.11.1",
         "hardhat-abi-exporter": "^2.10.0",
+        "solidity-ast": "^0.4.49",
+        "solidity-docgen": "^0.6.0-beta.35",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.3"
       }
@@ -2344,9 +2346,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -15561,7 +15563,6 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -17703,8 +17704,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/next-tick": {
       "version": "1.1.0",
@@ -19301,6 +19301,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/solidity-ast": {
+      "version": "0.4.49",
+      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.49.tgz",
+      "integrity": "sha512-Pr5sCAj1SFqzwFZw1HPKSq0PehlQNdM8GwKyAVYh2DOn7/cCK8LUKD1HeHnKtTgBW7hi9h4nnnan7hpAg5RhWQ==",
+      "dev": true
+    },
     "node_modules/solidity-coverage": {
       "version": "0.7.22",
       "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.7.22.tgz",
@@ -19381,6 +19387,19 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/solidity-docgen": {
+      "version": "0.6.0-beta.35",
+      "resolved": "https://registry.npmjs.org/solidity-docgen/-/solidity-docgen-0.6.0-beta.35.tgz",
+      "integrity": "sha512-9QdwK1THk/MWIdq1PEW/6dvtND0pUqpFTsbKwwU9YQIMYuRhH1lek9SsgnsGGYtdJ0VTrXXcVT30q20a8Y610A==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7",
+        "solidity-ast": "^0.4.38"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.8.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -20309,7 +20328,6 @@
       "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -21853,8 +21871,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/wordwrapjs": {
       "version": "4.0.1",
@@ -23863,9 +23880,9 @@
       }
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true
     },
     "acorn-walk": {
@@ -34298,7 +34315,6 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -35949,8 +35965,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "next-tick": {
       "version": "1.1.0",
@@ -37192,6 +37207,12 @@
         }
       }
     },
+    "solidity-ast": {
+      "version": "0.4.49",
+      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.49.tgz",
+      "integrity": "sha512-Pr5sCAj1SFqzwFZw1HPKSq0PehlQNdM8GwKyAVYh2DOn7/cCK8LUKD1HeHnKtTgBW7hi9h4nnnan7hpAg5RhWQ==",
+      "dev": true
+    },
     "solidity-coverage": {
       "version": "0.7.22",
       "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.7.22.tgz",
@@ -37258,6 +37279,16 @@
           "dev": true,
           "peer": true
         }
+      }
+    },
+    "solidity-docgen": {
+      "version": "0.6.0-beta.35",
+      "resolved": "https://registry.npmjs.org/solidity-docgen/-/solidity-docgen-0.6.0-beta.35.tgz",
+      "integrity": "sha512-9QdwK1THk/MWIdq1PEW/6dvtND0pUqpFTsbKwwU9YQIMYuRhH1lek9SsgnsGGYtdJ0VTrXXcVT30q20a8Y610A==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7",
+        "solidity-ast": "^0.4.38"
       }
     },
     "source-map": {
@@ -37981,8 +38012,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
       "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "ultron": {
       "version": "1.1.1",
@@ -39342,8 +39372,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "wordwrapjs": {
       "version": "4.0.1",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -11,6 +11,8 @@
     "dotenv": "^16.0.2",
     "hardhat": "^2.11.1",
     "hardhat-abi-exporter": "^2.10.0",
+    "solidity-ast": "^0.4.49",
+    "solidity-docgen": "^0.6.0-beta.35",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3"
   },


### PR DESCRIPTION
Docs are generated for all contract files, but they are all empty except `IFlexiSwap.sol`. 

This problem relies on `solidity-docgen` library which can not exclude contract files based on their full path, it works only for folders. Seems that implemented approach is the best solution for this issue without any changes to paths in contract imports.

Also custom error 
```solidity
error CounterOfferAlreadyExists(uint256 tradeId, uint256 counterOfferItemsId)
```
was changed to 
```solidity
error CounterOfferDoesNotExist(uint256 tradeId, uint256 itemsId)
```
for better namings as all other errors/events have similar namings.
    